### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ExponentiallyDigital/bulk-jira-cloud-sprint-creation/security/code-scanning/1](https://github.com/ExponentiallyDigital/bulk-jira-cloud-sprint-creation/security/code-scanning/1)

The optimal fix is to add an explicit `permissions` block to the workflow, so that the minimal necessary permissions are granted to the `GITHUB_TOKEN` for this job or the workflow as a whole. For this workflow, a `permissions` block with `contents: read` suffices; this allows the job to read the repository contents but not to write to them or take sensitive actions. The `permissions` block can be placed at the root of the workflow, immediately after the `name` key, so its scope applies to all jobs unless overridden (which is fine here since there is only one job).

**Files/regions to change:**  
- In `.github/workflows/build.yml`, add the `permissions` block after the `name:`.

**What is needed:**  
- Insert the following lines after the workflow name:
  ```yaml
  permissions:
    contents: read
  ```
No imports or other definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
